### PR TITLE
Refocus profile on full legacy PHP upgrade service

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You keep shipping features while the upgrade runs. Your team learns the tooling,
 Instant upgrades of hundreds of thousands of lines are only possible with automation. So I build it:
 
 * 🚀 [**Rector**](https://github.com/rectorphp/rector) — the instant upgrade and refactoring tool for PHP
-* 🐹 [**Recongo**](https://github.com/TomasVotruba/recongo) — Rector-like automated refactoring, written in Go
+* 🐹 **Recongo** *(private, in the works)* — Rector-like automated refactoring, written in Go
 * 📏 [**lines**](https://github.com/TomasVotruba/lines) — measure project size and used PHP features, zero dependencies
 * 🔍 [**type-coverage**](https://github.com/TomasVotruba/type-coverage) — PHPStan extension to require minimal type coverage
 * 🧹 [**unused-public**](https://github.com/TomasVotruba/unused-public) and [**class-leak**](https://github.com/TomasVotruba/class-leak) — find the dead code before you migrate it

--- a/README.md
+++ b/README.md
@@ -1,30 +1,51 @@
-# Hi, I'm Tomas, and I love Legacy
+# Hi, I'm Tomas — I Upgrade Legacy PHP Projects
 
-Nothing excites me more than good old legacy code. A code that can be improved light-years in a matter of few-days work. Not tedious and repetitive work. But with intelligent modern automated almost-futuristic tools.
+**Since 2014**, I take PHP projects stuck on old versions and frameworks, and bring them to the current stable one. Not a workshop, not a report you file away — the actual upgrade, delivered and merged.
 
 <br>
 
 > "If you really want to do something, you'll find a way.
 >
 > If you don't, you'll find an excuse."
- 
-<br>
-
-My biggest passion is **to innovate in the area of "impossible" and help developers to be happier** :heart: at their daily work. 
-
-If you're happy, you enjoy your work and life more, don't you? :wink:
 
 <br>
 
-## I Love to Share and Work
+## ✅ I'm Open to Upgrade Your Project
 
-* :rocket: I work on [Rector](http://github.com/rectorphp/rector) to help you forget about technical debt and upgrade from PHP 5.6 to PHP 8.1 in a day :muscle:
-* :paintbrush:  I **blog weekly** about PHP and cool coding shortcuts at [tomasvotruba.com](https://tomasvotruba.com)
-* :book: I wrote a book about Rector - [The Power of Automated Refactoring](https://leanpub.com/rector-the-power-of-automated-refactoring) together with my childhood hero
-* ❤️ Do you **enjoy tasty fruits** of my work? Support me at [Github Sponsors](https://github.com/sponsors/TomasVotruba) 
-* :bird:  I **tweet** about ideas worth learning at [@votrubaT](https://twitter.com/votrubat)
-* :hammer: Currently, I help successful PHP projects to turn their legacy around to **modern, productive code, and fun project to work with**.
+Full upgrade service, end to end:
+
+* **PHP 5.3 → 8.5** — version by version, your test suite green at every step
+* **Framework jumps** — Symfony 2 → 7, Laravel 5 → 12, Nette, Zend/Laminas
+* **Legacy → framework** — from no-framework or a homegrown one to something maintained
+* **PHPUnit, Doctrine, and the rest of your `composer.json`** — the dependencies that block everything else
+* **Static analysis from zero** — PHPStan running in CI, at a level your team can hold
+
+You keep shipping features while the upgrade runs. Your team learns the tooling, so the next upgrade is yours to do.
+
+👉 **[Let's talk about your project](https://tomasvotruba.com/contact)**
 
 <br>
 
-Do you want your code to be like that? [Let me know](https://tomasvotruba.com/contact)
+## 🛠️ Tools I Build to Make It Possible
+
+Instant upgrades of hundreds of thousands of lines are only possible with automation. So I build it:
+
+* 🚀 [**Rector**](https://github.com/rectorphp/rector) — the instant upgrade and refactoring tool for PHP
+* 🐹 [**Recongo**](https://github.com/TomasVotruba/recongo) — Rector-like automated refactoring, written in Go
+* 📏 [**lines**](https://github.com/TomasVotruba/lines) — measure project size and used PHP features, zero dependencies
+* 🔍 [**type-coverage**](https://github.com/TomasVotruba/type-coverage) — PHPStan extension to require minimal type coverage
+* 🧹 [**unused-public**](https://github.com/TomasVotruba/unused-public) and [**class-leak**](https://github.com/TomasVotruba/class-leak) — find the dead code before you migrate it
+* 🩺 [**phpstan-bodyscan**](https://github.com/TomasVotruba/phpstan-bodyscan) — error count per PHPStan level, so you know where you stand
+
+<br>
+
+## 📚 I Share What I Learn
+
+* 🖌️ I **blog weekly** about upgrades, static analysis and PHP at [tomasvotruba.com](https://tomasvotruba.com)
+* 📖 I wrote [**The Power of Automated Refactoring**](https://leanpub.com/rector-the-power-of-automated-refactoring) with my childhood hero
+* 🐦 I post ideas worth learning at [@votrubaT](https://twitter.com/votrubat)
+* ❤️ Do you enjoy the tasty fruits of my work? Support me at [GitHub Sponsors](https://github.com/sponsors/TomasVotruba)
+
+<br>
+
+**Legacy code isn't a problem — it's the code that made your business money. Let's make it fun to work with again.**


### PR DESCRIPTION
Rewrites the GitHub profile README around one message: **I'm open to upgrade your legacy PHP project, and I've been doing it since 2014.**

## What changed

**Headline** — from a general love of legacy to a concrete offer:

```diff
-# Hi, I'm Tomas, and I love Legacy
-
-Nothing excites me more than good old legacy code. A code that can be improved light-years in a matter of few-days work.
+# Hi, I'm Tomas — I Upgrade Legacy PHP Projects
+
+**Since 2014**, I take PHP projects stuck on old versions and frameworks, and bring them to the current stable one. Not a workshop, not a report you file away — the actual upgrade, delivered and merged.
```

**New "I'm Open to Upgrade Your Project" section** — spells out the full delivery scope (PHP 5.3 → 8.5, Symfony/Laravel/Nette/Laminas jumps, dependency unblocking, PHPStan in CI) with a single call to action, instead of burying the offer in the last bullet.

**New "Tools I Build to Make It Possible" section** — the upgrade tooling now stands on its own, with Rector joined by the rest of the toolchain:

- Recongo *(private, in the works)* — the Go version, Rector-like automated refactoring
- [lines](https://github.com/TomasVotruba/lines), [type-coverage](https://github.com/TomasVotruba/type-coverage), [unused-public](https://github.com/TomasVotruba/unused-public), [class-leak](https://github.com/TomasVotruba/class-leak), [phpstan-bodyscan](https://github.com/TomasVotruba/phpstan-bodyscan)

The old Rector line also claimed "PHP 5.6 to PHP 8.1", which is now several versions stale.

**Kept** — the quote, the book, the blog, Twitter, GitHub Sponsors.
